### PR TITLE
enlarge ldata to pass mandelbrot.decaf

### DIFF
--- a/testAll.py
+++ b/testAll.py
@@ -67,7 +67,7 @@ def run_jvm(bytecode_dir: str, output: str) -> bool:
 
 # running spim
 def run_spim(asm_file: str, output: str) -> bool:
-    return run(['spim', '-quiet', '-file', asm_file], output, True)
+    return run(['spim', '-quiet', '-ldata', '2000000',  '-file', asm_file], output, True)
 
 # tester
 class Tester:


### PR DESCRIPTION
在增加了本学期的feature以后，默认的SPIM参数就跑不过mandelbrot.decaf了，为了testAll出正确结果，需要放宽模拟器data段的大小限制